### PR TITLE
Use Fixed Version for nebula-test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     compile 'com.netflix.nebula:nebula-release-plugin:4.0.1'
     compile 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.6.3'
 
-    testCompile('com.netflix.nebula:nebula-test:latest.release') {
+    testCompile('com.netflix.nebula:nebula-test:4.2.2') {
         exclude group: 'org.codehaus.groovy'
     }
 }


### PR DESCRIPTION
Update nebula-test to use a fixed version instead of `latest.release`.  The dynamic version is used in the generated pom, causing plugin releases to fail on publish with this message:

```
Invalid version for Dependency {groupId=com.netflix.nebula, artifactId=nebula-test, version=latest.release, type=jar} - uses invalid dynamic version syntax.
```