### PR TITLE
Upgrade buildscans to latest plugin so it works with gradle 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,6 @@ dependencies {
     compile 'com.netflix.nebula:nebula-project-plugin:latest.release'
     compile 'com.netflix.nebula:nebula-release-plugin:latest.release'
 
-    compile 'com.gradle:build-scan-plugin:2.+'
     compile 'com.gradle.publish:plugin-publish-plugin:0.9.7'
     compile 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:latest.release'
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     compile 'com.netflix.nebula:nebula-project-plugin:latest.release'
     compile 'com.netflix.nebula:nebula-release-plugin:latest.release'
 
-    compile 'com.gradle:build-scan-plugin:1.+'
+    compile 'com.gradle:build-scan-plugin:2.+'
     compile 'com.gradle.publish:plugin-publish-plugin:0.9.7'
     compile 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:latest.release'
 

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -4,16 +4,12 @@
             "locked": "0.9.7",
             "requested": "0.9.7"
         },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
-        },
         "com.netflix.nebula:gradle-contacts-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.1.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "6.1.1",
+            "locked": "7.0.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-extra-configurations-plugin": {
@@ -21,27 +17,27 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-java-cross-compile-plugin": {
-            "locked": "2.0.1",
+            "locked": "2.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-bintray-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "5.1.1",
+            "locked": "5.1.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-publishing-plugin": {
-            "locked": "9.0.1",
+            "locked": "9.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-release-plugin": {
-            "locked": "8.0.1",
+            "locked": "8.0.3",
             "requested": "latest.release"
         },
         "org.kt3k.gradle.plugin:coveralls-gradle-plugin": {
@@ -54,16 +50,12 @@
             "locked": "0.9.7",
             "requested": "0.9.7"
         },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
-        },
         "com.netflix.nebula:gradle-contacts-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.1.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "6.1.1",
+            "locked": "7.0.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-extra-configurations-plugin": {
@@ -71,27 +63,27 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-java-cross-compile-plugin": {
-            "locked": "2.0.1",
+            "locked": "2.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-bintray-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "5.1.1",
+            "locked": "5.1.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-publishing-plugin": {
-            "locked": "9.0.1",
+            "locked": "9.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-release-plugin": {
-            "locked": "8.0.1",
+            "locked": "8.0.3",
             "requested": "latest.release"
         },
         "org.kt3k.gradle.plugin:coveralls-gradle-plugin": {
@@ -104,16 +96,12 @@
             "locked": "0.9.7",
             "requested": "0.9.7"
         },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
-        },
         "com.netflix.nebula:gradle-contacts-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.1.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "6.1.1",
+            "locked": "7.0.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-extra-configurations-plugin": {
@@ -121,27 +109,27 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-java-cross-compile-plugin": {
-            "locked": "2.0.1",
+            "locked": "2.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-bintray-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "5.1.1",
+            "locked": "5.1.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-publishing-plugin": {
-            "locked": "9.0.1",
+            "locked": "9.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-release-plugin": {
-            "locked": "8.0.1",
+            "locked": "8.0.3",
             "requested": "latest.release"
         },
         "org.kt3k.gradle.plugin:coveralls-gradle-plugin": {
@@ -154,16 +142,12 @@
             "locked": "0.9.7",
             "requested": "0.9.7"
         },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
-        },
         "com.netflix.nebula:gradle-contacts-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.1.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "6.1.1",
+            "locked": "7.0.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-extra-configurations-plugin": {
@@ -171,31 +155,31 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-java-cross-compile-plugin": {
-            "locked": "2.0.1",
+            "locked": "2.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-bintray-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "5.1.1",
+            "locked": "5.1.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-publishing-plugin": {
-            "locked": "9.0.1",
+            "locked": "9.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-release-plugin": {
-            "locked": "8.0.1",
+            "locked": "8.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.0.1",
+            "locked": "7.1.0",
             "requested": "latest.release"
         },
         "org.kt3k.gradle.plugin:coveralls-gradle-plugin": {
@@ -208,16 +192,12 @@
             "locked": "0.9.7",
             "requested": "0.9.7"
         },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
-        },
         "com.netflix.nebula:gradle-contacts-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.1.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "6.1.1",
+            "locked": "7.0.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-extra-configurations-plugin": {
@@ -225,31 +205,31 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-java-cross-compile-plugin": {
-            "locked": "2.0.1",
+            "locked": "2.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-bintray-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "5.1.1",
+            "locked": "5.1.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-publishing-plugin": {
-            "locked": "9.0.1",
+            "locked": "9.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-release-plugin": {
-            "locked": "8.0.1",
+            "locked": "8.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.0.1",
+            "locked": "7.1.0",
             "requested": "latest.release"
         },
         "org.kt3k.gradle.plugin:coveralls-gradle-plugin": {
@@ -262,16 +242,12 @@
             "locked": "0.9.7",
             "requested": "0.9.7"
         },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
-        },
         "com.netflix.nebula:gradle-contacts-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.1.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "6.1.1",
+            "locked": "7.0.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-extra-configurations-plugin": {
@@ -279,31 +255,31 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-java-cross-compile-plugin": {
-            "locked": "2.0.1",
+            "locked": "2.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-bintray-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "5.1.1",
+            "locked": "5.1.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-publishing-plugin": {
-            "locked": "9.0.1",
+            "locked": "9.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-release-plugin": {
-            "locked": "8.0.1",
+            "locked": "8.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.0.1",
+            "locked": "7.1.0",
             "requested": "latest.release"
         },
         "org.kt3k.gradle.plugin:coveralls-gradle-plugin": {
@@ -316,16 +292,12 @@
             "locked": "0.9.7",
             "requested": "0.9.7"
         },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
-        },
         "com.netflix.nebula:gradle-contacts-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.1.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "6.1.1",
+            "locked": "7.0.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-extra-configurations-plugin": {
@@ -333,31 +305,31 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-java-cross-compile-plugin": {
-            "locked": "2.0.1",
+            "locked": "2.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-bintray-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "5.1.1",
+            "locked": "5.1.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-publishing-plugin": {
-            "locked": "9.0.1",
+            "locked": "9.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-release-plugin": {
-            "locked": "8.0.1",
+            "locked": "8.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.0.1",
+            "locked": "7.1.0",
             "requested": "latest.release"
         },
         "org.kt3k.gradle.plugin:coveralls-gradle-plugin": {
@@ -380,16 +352,12 @@
             "locked": "0.9.7",
             "requested": "0.9.7"
         },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
-        },
         "com.netflix.nebula:gradle-contacts-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.1.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "6.1.1",
+            "locked": "7.0.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-extra-configurations-plugin": {
@@ -397,27 +365,27 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-java-cross-compile-plugin": {
-            "locked": "2.0.1",
+            "locked": "2.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-bintray-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "5.1.1",
+            "locked": "5.1.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-publishing-plugin": {
-            "locked": "9.0.1",
+            "locked": "9.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-release-plugin": {
-            "locked": "8.0.1",
+            "locked": "8.0.3",
             "requested": "latest.release"
         },
         "org.kt3k.gradle.plugin:coveralls-gradle-plugin": {
@@ -430,16 +398,12 @@
             "locked": "0.9.7",
             "requested": "0.9.7"
         },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
-        },
         "com.netflix.nebula:gradle-contacts-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.1.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "6.1.1",
+            "locked": "7.0.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-extra-configurations-plugin": {
@@ -447,27 +411,27 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-java-cross-compile-plugin": {
-            "locked": "2.0.1",
+            "locked": "2.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-bintray-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "5.1.1",
+            "locked": "5.1.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-publishing-plugin": {
-            "locked": "9.0.1",
+            "locked": "9.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-release-plugin": {
-            "locked": "8.0.1",
+            "locked": "8.0.3",
             "requested": "latest.release"
         },
         "org.kt3k.gradle.plugin:coveralls-gradle-plugin": {
@@ -480,16 +444,12 @@
             "locked": "0.9.7",
             "requested": "0.9.7"
         },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
-        },
         "com.netflix.nebula:gradle-contacts-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.1.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "6.1.1",
+            "locked": "7.0.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-extra-configurations-plugin": {
@@ -497,31 +457,31 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-java-cross-compile-plugin": {
-            "locked": "2.0.1",
+            "locked": "2.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-bintray-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "5.1.1",
+            "locked": "5.1.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-publishing-plugin": {
-            "locked": "9.0.1",
+            "locked": "9.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-release-plugin": {
-            "locked": "8.0.1",
+            "locked": "8.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.0.1",
+            "locked": "7.1.0",
             "requested": "latest.release"
         },
         "org.kt3k.gradle.plugin:coveralls-gradle-plugin": {
@@ -534,16 +494,12 @@
             "locked": "0.9.7",
             "requested": "0.9.7"
         },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
-        },
         "com.netflix.nebula:gradle-contacts-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.1.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "6.1.1",
+            "locked": "7.0.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-extra-configurations-plugin": {
@@ -551,31 +507,31 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-java-cross-compile-plugin": {
-            "locked": "2.0.1",
+            "locked": "2.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-bintray-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "5.1.1",
+            "locked": "5.1.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-publishing-plugin": {
-            "locked": "9.0.1",
+            "locked": "9.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-release-plugin": {
-            "locked": "8.0.1",
+            "locked": "8.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.0.1",
+            "locked": "7.1.0",
             "requested": "latest.release"
         },
         "org.kt3k.gradle.plugin:coveralls-gradle-plugin": {
@@ -588,16 +544,12 @@
             "locked": "0.9.7",
             "requested": "0.9.7"
         },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
-        },
         "com.netflix.nebula:gradle-contacts-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.1.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "6.1.1",
+            "locked": "7.0.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-extra-configurations-plugin": {
@@ -605,31 +557,31 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-java-cross-compile-plugin": {
-            "locked": "2.0.1",
+            "locked": "2.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-bintray-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "5.1.1",
+            "locked": "5.1.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-publishing-plugin": {
-            "locked": "9.0.1",
+            "locked": "9.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-release-plugin": {
-            "locked": "8.0.1",
+            "locked": "8.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.0.1",
+            "locked": "7.1.0",
             "requested": "latest.release"
         },
         "org.kt3k.gradle.plugin:coveralls-gradle-plugin": {
@@ -642,16 +594,12 @@
             "locked": "0.9.7",
             "requested": "0.9.7"
         },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
-        },
         "com.netflix.nebula:gradle-contacts-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.1.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "6.1.1",
+            "locked": "7.0.1",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-extra-configurations-plugin": {
@@ -659,31 +607,31 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-java-cross-compile-plugin": {
-            "locked": "2.0.1",
+            "locked": "2.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-bintray-plugin": {
-            "locked": "4.0.1",
+            "locked": "4.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "5.1.1",
+            "locked": "5.1.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-publishing-plugin": {
-            "locked": "9.0.1",
+            "locked": "9.0.2",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-release-plugin": {
-            "locked": "8.0.1",
+            "locked": "8.0.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.0.1",
+            "locked": "7.1.0",
             "requested": "latest.release"
         },
         "org.kt3k.gradle.plugin:coveralls-gradle-plugin": {


### PR DESCRIPTION
I noticed the following error when using build scans plugin 1.x

```
java.lang.NoClassDefFoundError: org/gradle/internal/operations/notify/BuildOperationNotificationListener2
        at com.gradle.scan.plugin.internal.i.i.a(SourceFile:19)
        at com.gradle.scan.plugin.internal.i.g.a(SourceFile:45)
        at com.gradle.scan.plugin.internal.i.g.a(SourceFile:25)
        at com.gradle.scan.plugin.BuildScanPlugin.a(SourceFile:448)
        at com.gradle.scan.plugin.BuildScanPlugin.a(SourceFile:416)
        at com.gradle.scan.plugin.BuildScanPlugin.apply(SourceFile:257)
        at com.gradle.scan.plugin.BuildScanPlugin.apply(SourceFile:130)
        at org.gradle.api.internal.plugins.ImperativeOnlyPluginTarget.applyImperative(ImperativeOnlyPluginTarget.java:42)
        at org.gradle.api.internal.plugins.RuleBasedPluginTarget.applyImperative(RuleBasedPluginTarget.java:50)
```

Looks like the change was introduced on this pull request -> https://github.com/gradle/gradle/pull/7023/files

So this would break with gradle 5

Removing build-scans plugin since we don't really use this
