### PR TITLE
Remove build scans plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,6 @@ dependencies {
     compile 'com.netflix.nebula:nebula-project-plugin:latest.release'
     compile 'com.netflix.nebula:nebula-release-plugin:latest.release'
 
-    compile 'com.gradle:build-scan-plugin:2.+'
     compile 'com.gradle.publish:plugin-publish-plugin:0.9.7'
     compile 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:latest.release'
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     compile 'com.netflix.nebula:nebula-project-plugin:latest.release'
     compile 'com.netflix.nebula:nebula-release-plugin:latest.release'
 
-    compile 'com.gradle:build-scan-plugin:1.+'
+    compile 'com.gradle:build-scan-plugin:2.+'
     compile 'com.gradle.publish:plugin-publish-plugin:0.9.7'
     compile 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:latest.release'
 

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -4,10 +4,6 @@
             "locked": "0.9.7",
             "requested": "0.9.7"
         },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
-        },
         "com.netflix.nebula:gradle-contacts-plugin": {
             "locked": "4.0.1",
             "requested": "latest.release"
@@ -53,10 +49,6 @@
         "com.gradle.publish:plugin-publish-plugin": {
             "locked": "0.9.7",
             "requested": "0.9.7"
-        },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
         },
         "com.netflix.nebula:gradle-contacts-plugin": {
             "locked": "4.0.1",
@@ -104,10 +96,6 @@
             "locked": "0.9.7",
             "requested": "0.9.7"
         },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
-        },
         "com.netflix.nebula:gradle-contacts-plugin": {
             "locked": "4.0.1",
             "requested": "latest.release"
@@ -153,10 +141,6 @@
         "com.gradle.publish:plugin-publish-plugin": {
             "locked": "0.9.7",
             "requested": "0.9.7"
-        },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
         },
         "com.netflix.nebula:gradle-contacts-plugin": {
             "locked": "4.0.1",
@@ -208,10 +192,6 @@
             "locked": "0.9.7",
             "requested": "0.9.7"
         },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
-        },
         "com.netflix.nebula:gradle-contacts-plugin": {
             "locked": "4.0.1",
             "requested": "latest.release"
@@ -262,10 +242,6 @@
             "locked": "0.9.7",
             "requested": "0.9.7"
         },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
-        },
         "com.netflix.nebula:gradle-contacts-plugin": {
             "locked": "4.0.1",
             "requested": "latest.release"
@@ -315,10 +291,6 @@
         "com.gradle.publish:plugin-publish-plugin": {
             "locked": "0.9.7",
             "requested": "0.9.7"
-        },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
         },
         "com.netflix.nebula:gradle-contacts-plugin": {
             "locked": "4.0.1",
@@ -380,10 +352,6 @@
             "locked": "0.9.7",
             "requested": "0.9.7"
         },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
-        },
         "com.netflix.nebula:gradle-contacts-plugin": {
             "locked": "4.0.1",
             "requested": "latest.release"
@@ -430,10 +398,6 @@
             "locked": "0.9.7",
             "requested": "0.9.7"
         },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
-        },
         "com.netflix.nebula:gradle-contacts-plugin": {
             "locked": "4.0.1",
             "requested": "latest.release"
@@ -479,10 +443,6 @@
         "com.gradle.publish:plugin-publish-plugin": {
             "locked": "0.9.7",
             "requested": "0.9.7"
-        },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
         },
         "com.netflix.nebula:gradle-contacts-plugin": {
             "locked": "4.0.1",
@@ -534,10 +494,6 @@
             "locked": "0.9.7",
             "requested": "0.9.7"
         },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
-        },
         "com.netflix.nebula:gradle-contacts-plugin": {
             "locked": "4.0.1",
             "requested": "latest.release"
@@ -588,10 +544,6 @@
             "locked": "0.9.7",
             "requested": "0.9.7"
         },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
-        },
         "com.netflix.nebula:gradle-contacts-plugin": {
             "locked": "4.0.1",
             "requested": "latest.release"
@@ -641,10 +593,6 @@
         "com.gradle.publish:plugin-publish-plugin": {
             "locked": "0.9.7",
             "requested": "0.9.7"
-        },
-        "com.gradle:build-scan-plugin": {
-            "locked": "1.16",
-            "requested": "1.+"
         },
         "com.netflix.nebula:gradle-contacts-plugin": {
             "locked": "4.0.1",

--- a/src/main/groovy/nebula/plugin/plugin/NebulaPluginPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/plugin/NebulaPluginPlugin.groovy
@@ -25,8 +25,7 @@ import org.gradle.api.tasks.testing.Test
  * Provide an environment for a Gradle plugin
  */
 class NebulaPluginPlugin implements Plugin<Project> {
-    static final GRADLE_PLUGIN_IDS = ['com.gradle.build-scan',
-                                      'groovy',
+    static final GRADLE_PLUGIN_IDS = ['groovy',
                                       'idea',
                                       'jacoco',
                                       'com.gradle.plugin-publish']
@@ -70,12 +69,7 @@ class NebulaPluginPlugin implements Plugin<Project> {
                 compile gradleApi()
                 testCompile 'com.netflix.nebula:nebula-test:7.+'
             }
-
-            buildScan {
-                licenseAgreementUrl = 'https://gradle.com/terms-of-service'
-                licenseAgree = 'yes'
-                publishAlways()
-            }
+            
 
             jacocoTestReport {
                 reports {


### PR DESCRIPTION
I noticed the following error when using build scans plugin 1.x and gradle nightly.

```
java.lang.NoClassDefFoundError: org/gradle/internal/operations/notify/BuildOperationNotificationListener2 at com.gradle.scan.plugin.internal.i.i.a(SourceFile:19) at com.gradle.scan.plugin.internal.i.g.a(SourceFile:45) at com.gradle.scan.plugin.internal.i.g.a(SourceFile:25) at com.gradle.scan.plugin.BuildScanPlugin.a(SourceFile:448) at com.gradle.scan.plugin.BuildScanPlugin.a(SourceFile:416) at com.gradle.scan.plugin.BuildScanPlugin.apply(SourceFile:257) at com.gradle.scan.plugin.BuildScanPlugin.apply(SourceFile:130) at org.gradle.api.internal.plugins.ImperativeOnlyPluginTarget.applyImperative(ImperativeOnlyPluginTarget.java:42) at org.gradle.api.internal.plugins.RuleBasedPluginTarget.applyImperative(RuleBasedPluginTarget.java:50)
```

This change was introduced on this pull request -> https://github.com/gradle/gradle/pull/7023/files

Right now we can't introduce this RC as part of our workflow because it would break backwards compatibility:

```
Caused by: com.gradle.scan.plugin.UnsupportedGradleVersionException: Version 2.0-rc-1-20181004085302-release of the build scan plugin requires Gradle 5.0 or later.
You are currently using Gradle 4.10.2.
```

Nebula plugin-plugin provides the build-scan plugin to plugins that use it. With this breaking changes, I believe providing the build-scan plugin creates issues with backward compatibility and doesn't provide that much of value.

Thought?
