### PR TITLE
Remove MaxPermSize from plugin-plugin

### DIFF
--- a/src/main/groovy/nebula/plugin/plugin/NebulaPluginPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/plugin/NebulaPluginPlugin.groovy
@@ -82,7 +82,6 @@ class NebulaPluginPlugin implements Plugin<Project> {
             tasks.withType(Test) { task ->
                 minHeapSize = '32m'
                 maxHeapSize = '256m'
-                jvmArgs "-XX:MaxPermSize=512m"
                 doFirst {
                     // Add the execution data only if the task runs
                     jacocoTestReport.executionData.from = files("$buildDir/jacoco/${task.name}.exec")


### PR DESCRIPTION
Removing `maxPermSize` from test jvm args as this was deprecated in Java 8

```
OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=512m; support was removed in 8.0
```