### PR TITLE
Introduce test logging events for all plugins

### DIFF
--- a/src/main/groovy/nebula/plugin/plugin/NebulaPluginPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/plugin/NebulaPluginPlugin.groovy
@@ -87,6 +87,9 @@ class NebulaPluginPlugin implements Plugin<Project> {
                     // Add the execution data only if the task runs
                     jacocoTestReport.executionData.from = files("$buildDir/jacoco/${task.name}.exec")
                 }
+                testLogging {
+                    events "PASSED", "FAILED", "SKIPPED"
+                }
             }
 
             if(tasks.findByName('artifactoryPublish')) {


### PR DESCRIPTION
One of our issues with TravisCI is the need for output while doing tests, specially if the test task takes longer than 10min.

We enabled test logging events for resolution rules and it helped a lot and also the output is great.

This change is a proposal to enable this to all our plugins by default. `nebula-publishing` plugin could really use this