### PR TITLE
Upgrade coveralls plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,9 @@ contacts {
 
 repositories {
     mavenCentral()
+    gradlePluginPortal()
 }
+
 dependencies {
     implementation 'com.netflix.nebula:nebula-oss-publishing-plugin:latest.release'
     implementation 'com.netflix.nebula:gradle-contacts-plugin:latest.release'
@@ -44,7 +46,7 @@ dependencies {
     implementation enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.9.10.+")
 
     implementation 'com.gradle.publish:plugin-publish-plugin:0.11.0'
-    implementation 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:latest.release'
+    implementation 'gradle.plugin.org.kt3k.gradle.plugin:coveralls-gradle-plugin:latest.release'
 
     testImplementation 'com.netflix.nebula:nebula-test:latest.release'
     testImplementation("org.ajoberstar.grgit:grgit-core:3.1.1") {

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -13,9 +13,9 @@ com.netflix.nebula:nebula-oss-publishing-plugin:1.1.3
 com.netflix.nebula:nebula-project-plugin:8.0.0
 com.netflix.nebula:nebula-publishing-plugin:17.3.2
 com.netflix.nebula:nebula-release-plugin:15.3.1
+gradle.plugin.org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.11.0
 org.jetbrains.kotlin:kotlin-stdlib-common:1.4.21
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.21
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.21
 org.jetbrains.kotlin:kotlin-stdlib:1.4.21
 org.jetbrains:annotations:13.0
-org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.3

--- a/gradle/dependency-locks/integTestCompileClasspath.lockfile
+++ b/gradle/dependency-locks/integTestCompileClasspath.lockfile
@@ -10,7 +10,7 @@ com.jcraft:jsch:0.1.54
 com.jcraft:jzlib:1.1.1
 com.netflix.nebula:gradle-contacts-plugin:5.1.0
 com.netflix.nebula:gradle-dependency-lock-plugin:11.1.3
-com.netflix.nebula:gradle-extra-configurations-plugin:5.0.3
+com.netflix.nebula:gradle-extra-configurations-plugin:6.0.0
 com.netflix.nebula:gradle-info-plugin:9.3.0
 com.netflix.nebula:gradle-java-cross-compile-plugin:4.3.0
 com.netflix.nebula:nebula-gradle-interop:1.0.11
@@ -20,6 +20,7 @@ com.netflix.nebula:nebula-publishing-plugin:17.3.2
 com.netflix.nebula:nebula-release-plugin:15.3.1
 com.netflix.nebula:nebula-test:8.1.0
 commons-io:commons-io:2.5
+gradle.plugin.org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.11.0
 junit:junit:4.12
 org.ajoberstar.grgit:grgit-core:3.1.1
 org.bouncycastle:bcpg-jdk15on:1.60
@@ -32,7 +33,6 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.21
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.21
 org.jetbrains.kotlin:kotlin-stdlib:1.4.21
 org.jetbrains:annotations:13.0
-org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.3
 org.objenesis:objenesis:2.4
 org.slf4j:slf4j-api:1.7.2
 org.spockframework:spock-core:1.3-groovy-2.4

--- a/gradle/dependency-locks/integTestRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/integTestRuntimeClasspath.lockfile
@@ -34,12 +34,13 @@ com.squareup.moshi:moshi:1.11.0
 com.squareup.okio:okio:1.17.5
 com.trilead:trilead-ssh2:1.0.0-build220
 commons-beanutils:commons-beanutils:1.8.0
-commons-codec:commons-codec:1.6
+commons-codec:commons-codec:1.11
 commons-collections:commons-collections:3.2.1
 commons-io:commons-io:2.5
 commons-lang:commons-lang:2.4
-commons-logging:commons-logging:1.1.3
+commons-logging:commons-logging:1.2
 de.regnis.q.sequence:sequence-library:1.0.3
+gradle.plugin.org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.11.0
 io.github.gradle-nexus:publish-plugin:1.0.0
 joda-time:joda-time:2.10
 junit:junit:4.12
@@ -51,9 +52,9 @@ net.sf.json-lib:json-lib:2.3
 net.sourceforge.nekohtml:nekohtml:1.9.16
 org.ajoberstar.grgit:grgit-core:4.0.2
 org.antlr:antlr-runtime:3.4
-org.apache.httpcomponents:httpclient:4.3
-org.apache.httpcomponents:httpcore:4.3
-org.apache.httpcomponents:httpmime:4.3
+org.apache.httpcomponents:httpclient:4.5.11
+org.apache.httpcomponents:httpcore:4.4.13
+org.apache.httpcomponents:httpmime:4.5.11
 org.apache.maven:maven-model:3.0.4
 org.bouncycastle:bcpg-jdk15on:1.64
 org.bouncycastle:bcpkix-jdk15on:1.64
@@ -66,7 +67,6 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.21
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.21
 org.jetbrains.kotlin:kotlin-stdlib:1.4.21
 org.jetbrains:annotations:13.0
-org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.3
 org.objenesis:objenesis:2.4
 org.slf4j:slf4j-api:1.7.2
 org.spockframework:spock-core:1.3-groovy-2.4

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -16,7 +16,7 @@ com.jcraft:jsch:0.1.55
 com.jcraft:jzlib:1.1.2
 com.netflix.nebula:gradle-contacts-plugin:5.1.0
 com.netflix.nebula:gradle-dependency-lock-plugin:11.1.3
-com.netflix.nebula:gradle-extra-configurations-plugin:5.0.3
+com.netflix.nebula:gradle-extra-configurations-plugin:6.0.0
 com.netflix.nebula:gradle-info-plugin:9.3.0
 com.netflix.nebula:gradle-java-cross-compile-plugin:4.3.0
 com.netflix.nebula:gradle-scm-plugin:5.1.0
@@ -31,11 +31,12 @@ com.squareup.moshi:moshi:1.11.0
 com.squareup.okio:okio:1.17.5
 com.trilead:trilead-ssh2:1.0.0-build220
 commons-beanutils:commons-beanutils:1.8.0
-commons-codec:commons-codec:1.6
+commons-codec:commons-codec:1.11
 commons-collections:commons-collections:3.2.1
 commons-lang:commons-lang:2.4
-commons-logging:commons-logging:1.1.3
+commons-logging:commons-logging:1.2
 de.regnis.q.sequence:sequence-library:1.0.3
+gradle.plugin.org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.11.0
 io.github.gradle-nexus:publish-plugin:1.0.0
 joda-time:joda-time:2.10
 net.java.dev.jna:jna-platform:5.7.0
@@ -46,9 +47,9 @@ net.sf.json-lib:json-lib:2.3
 net.sourceforge.nekohtml:nekohtml:1.9.16
 org.ajoberstar.grgit:grgit-core:4.0.2
 org.antlr:antlr-runtime:3.4
-org.apache.httpcomponents:httpclient:4.3
-org.apache.httpcomponents:httpcore:4.3
-org.apache.httpcomponents:httpmime:4.3
+org.apache.httpcomponents:httpclient:4.5.11
+org.apache.httpcomponents:httpcore:4.4.13
+org.apache.httpcomponents:httpmime:4.5.11
 org.apache.maven:maven-model:3.0.4
 org.bouncycastle:bcpg-jdk15on:1.64
 org.bouncycastle:bcpkix-jdk15on:1.64
@@ -60,7 +61,6 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.21
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.21
 org.jetbrains.kotlin:kotlin-stdlib:1.4.21
 org.jetbrains:annotations:13.0
-org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.3
 org.slf4j:slf4j-api:1.7.2
 org.tmatesoft.sqljet:sqljet:1.1.10
 org.tmatesoft.svnkit:svnkit:1.8.12

--- a/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -10,7 +10,7 @@ com.jcraft:jsch:0.1.54
 com.jcraft:jzlib:1.1.1
 com.netflix.nebula:gradle-contacts-plugin:5.1.0
 com.netflix.nebula:gradle-dependency-lock-plugin:11.1.3
-com.netflix.nebula:gradle-extra-configurations-plugin:5.0.3
+com.netflix.nebula:gradle-extra-configurations-plugin:6.0.0
 com.netflix.nebula:gradle-info-plugin:9.3.0
 com.netflix.nebula:gradle-java-cross-compile-plugin:4.3.0
 com.netflix.nebula:nebula-gradle-interop:1.0.11
@@ -20,6 +20,7 @@ com.netflix.nebula:nebula-publishing-plugin:17.3.2
 com.netflix.nebula:nebula-release-plugin:15.3.1
 com.netflix.nebula:nebula-test:8.1.0
 commons-io:commons-io:2.5
+gradle.plugin.org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.11.0
 junit:junit:4.12
 org.ajoberstar.grgit:grgit-core:3.1.1
 org.bouncycastle:bcpg-jdk15on:1.60
@@ -32,7 +33,6 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.21
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.21
 org.jetbrains.kotlin:kotlin-stdlib:1.4.21
 org.jetbrains:annotations:13.0
-org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.3
 org.objenesis:objenesis:2.4
 org.slf4j:slf4j-api:1.7.2
 org.spockframework:spock-core:1.3-groovy-2.4

--- a/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -34,12 +34,13 @@ com.squareup.moshi:moshi:1.11.0
 com.squareup.okio:okio:1.17.5
 com.trilead:trilead-ssh2:1.0.0-build220
 commons-beanutils:commons-beanutils:1.8.0
-commons-codec:commons-codec:1.6
+commons-codec:commons-codec:1.11
 commons-collections:commons-collections:3.2.1
 commons-io:commons-io:2.5
 commons-lang:commons-lang:2.4
-commons-logging:commons-logging:1.1.3
+commons-logging:commons-logging:1.2
 de.regnis.q.sequence:sequence-library:1.0.3
+gradle.plugin.org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.11.0
 io.github.gradle-nexus:publish-plugin:1.0.0
 joda-time:joda-time:2.10
 junit:junit:4.12
@@ -51,9 +52,9 @@ net.sf.json-lib:json-lib:2.3
 net.sourceforge.nekohtml:nekohtml:1.9.16
 org.ajoberstar.grgit:grgit-core:4.0.2
 org.antlr:antlr-runtime:3.4
-org.apache.httpcomponents:httpclient:4.3
-org.apache.httpcomponents:httpcore:4.3
-org.apache.httpcomponents:httpmime:4.3
+org.apache.httpcomponents:httpclient:4.5.11
+org.apache.httpcomponents:httpcore:4.4.13
+org.apache.httpcomponents:httpmime:4.5.11
 org.apache.maven:maven-model:3.0.4
 org.bouncycastle:bcpg-jdk15on:1.64
 org.bouncycastle:bcpkix-jdk15on:1.64
@@ -66,7 +67,6 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.21
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.21
 org.jetbrains.kotlin:kotlin-stdlib:1.4.21
 org.jetbrains:annotations:13.0
-org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.3
 org.objenesis:objenesis:2.4
 org.slf4j:slf4j-api:1.7.2
 org.spockframework:spock-core:1.3-groovy-2.4


### PR DESCRIPTION
The latest coveralls plugin is no longer published on GitHub, but
only on the Gradle plugin portal. This PR updates the dependency
coordinates and lock file in order to use the latest release.