### PR TITLE
Update Gradle Report property for 7.1 compatibility

### DIFF
--- a/src/main/groovy/nebula/plugin/plugin/NebulaPluginPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/plugin/NebulaPluginPlugin.groovy
@@ -109,8 +109,8 @@ class NebulaPluginPlugin implements Plugin<Project> {
 
             jacocoTestReport {
                 reports {
-                    xml.enabled = true // coveralls plugin depends on xml format report
-                    html.enabled = true
+                    xml.required = true // coveralls plugin depends on xml format report
+                    html.required = true
                 }
             }
 


### PR DESCRIPTION
Gradle 7.1 will deprecate Report.enabled property which has a replacement property `required`.
https://github.com/gradle/gradle/pull/16764