### PR TITLE
Use explicit property assignment

### DIFF
--- a/src/main/groovy/nebula/plugin/plugin/NebulaPluginPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/plugin/NebulaPluginPlugin.groovy
@@ -96,7 +96,7 @@ class NebulaPluginPlugin implements Plugin<Project> {
 
             repositories {
                 maven {
-                    url 'https://plugins.gradle.org/m2/'
+                    url = 'https://plugins.gradle.org/m2/'
                     metadataSources {
                         mavenPom()
                         artifact()


### PR DESCRIPTION
We plan to deprecate the generation for space assignment methods. See
* https://github.com/gradle/gradle/issues/31413